### PR TITLE
feat(seo): implement metadata and social tags

### DIFF
--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,9 +1,44 @@
 import React from "react";
+import { Metadata } from "next";
 import { getInitialBlogs } from "@/utils/blog";
+import { getTranslations } from "next-intl/server";
 
 import BlogList from "@/components/common/blog/BlogList";
 
-// Component to display the blog page(/blog) with initial blogs and a load more button
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Blog" });
+
+  const pageTitle = t("title");
+  const pageDescription = t("description");
+
+  return {
+    title: pageTitle,
+    description: pageDescription,
+    openGraph: {
+      title: pageTitle,
+      description: pageDescription,
+      url: `/${locale}/blog`,
+      siteName: "React Kolkata",
+      locale: locale,
+      type: "website",
+      // Optional: can add a default image
+      // images: ['/images/blog-og.jpg'],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: pageTitle,
+      description: pageDescription,
+      // Optional: can add a default image
+      // images: ['/images/blog-twitter.jpg'],
+    },
+  };
+}
+
 const BlogPage = async () => {
   const { posts: initialBlogs, endCursor: initialEndCursor, error } = await getInitialBlogs();
 

--- a/src/app/[locale]/contributors/page.tsx
+++ b/src/app/[locale]/contributors/page.tsx
@@ -10,9 +10,29 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "Contributors" });
 
+  const pageTitle = t("title");
+  const pageDescription = t("description");
+
   return {
-    title: t("title"),
-    description: t("description"),
+    title: pageTitle,
+    description: pageDescription,
+    openGraph: {
+      title: pageTitle,
+      description: pageDescription,
+      url: `/${locale}/contributors`,
+      siteName: "React Kolkata",
+      locale: locale,
+      type: "website",
+      // Optional: can add a specific image
+      // images: ['/images/contributors-og.jpg'],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: pageTitle,
+      description: pageDescription,
+      // Optional: can add a specific image
+      // images: ['/images/contributors-twitter.jpg'],
+    },
   };
 }
 

--- a/src/app/[locale]/events/page.tsx
+++ b/src/app/[locale]/events/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next";
 import CfpCard from "@/modules/home/(sections)/event/cfp-card";
 import ComingSoonCard from "@/modules/home/(sections)/event/coming-soon-card";
 import EventCard from "@/modules/home/(sections)/event/event-card";
@@ -5,10 +6,45 @@ import EventCardCompact from "@/modules/home/(sections)/event/event-card-compact
 import VolunteerCard from "@/modules/home/(sections)/event/volunteer-card";
 import { EVENT_STATUS } from "@/types/event";
 import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 
 import { getEventStatus } from "@/lib/calendar-utils";
 import AnimatedSection from "@/components/custom/animated-section";
 import { events } from "@/base/data/dummy";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Events" });
+
+  const pageTitle = t("title");
+  const pageDescription = t("description");
+
+  return {
+    title: pageTitle,
+    description: pageDescription,
+    openGraph: {
+      title: pageTitle,
+      description: pageDescription,
+      url: `/${locale}/events`,
+      siteName: "React Kolkata",
+      locale: locale,
+      type: "website",
+      // Optional: can add a specific image
+      // images: ['/images/events-og.jpg'],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: pageTitle,
+      description: pageDescription,
+      // Optional: can add a specific image
+      // images: ['/images/events-twitter.jpg'],
+    },
+  };
+}
 
 export default function EventsPage() {
   const t = useTranslations("Events");
@@ -38,7 +74,6 @@ export default function EventsPage() {
           </div>
         </div>
 
-        {/* Upcoming Events Section */}
         <section className="space-y-6">
           <h2
             className="text-2xl font-semibold tracking-tight"
@@ -61,7 +96,6 @@ export default function EventsPage() {
               </div>
             </div>
           ) : (
-            /* Show only Coming Soon card when no upcoming events */
             <div className="grid gap-6 lg:grid-cols-3">
               <div className="lg:col-span-2">
                 <ComingSoonCard />
@@ -78,7 +112,6 @@ export default function EventsPage() {
           )}
         </section>
 
-        {/* Past Events Section */}
         {pastEvents.length > 0 && (
           <section className="space-y-6">
             <h2
@@ -89,7 +122,6 @@ export default function EventsPage() {
             </h2>
 
             <div className="grid gap-6 lg:grid-cols-3 lg:items-start">
-              {/* Large past event card - takes 2 columns */}
               <div className="lg:col-span-2">
                 {pastEvents.slice(0, 1).map((event) => (
                   <EventCard key={event.id} event={event} />
@@ -113,7 +145,6 @@ export default function EventsPage() {
           </section>
         )}
 
-        {/* No events message */}
         {upcomingEvents.length === 0 && pastEvents.length === 0 && (
           <div className="py-12 text-center">
             <p className="text-slate-300">No events found.</p>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { notFound } from "next/navigation";
+import Script from "next/script";
 import { siteConfig } from "@/modules/home/meta/site";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { NextIntlClientProvider } from "next-intl";
@@ -18,6 +19,22 @@ type RootLayoutProps = Readonly<{
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }>;
+
+// Define Organization JSON-LD data
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "React Kolkata",
+  url: "https://reactkolkata.com",
+  logo: "https://reactkolkata.com/logo.svg",
+  sameAs: [
+    "https://x.com/reactkolkata",
+    "https://github.com/reactplay/react-kolkata",
+    "https://www.linkedin.com/showcase/react-kolkata",
+    "https://www.youtube.com/@ReactPlayIO",
+    // can add Discord if applicable
+  ],
+};
 
 export default async function RootLayout({ children, params }: RootLayoutProps) {
   const { locale } = await params;
@@ -39,6 +56,14 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
         </NextIntlClientProvider>
 
         {process.env.NEXT_PUBLIC_GA_ID && <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />}
+
+        <Script
+          id="organization-schema"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(organizationJsonLd),
+          }}
+        />
       </body>
     </html>
   );

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,31 @@
+import { Metadata } from "next";
 import LandingPage from "@/modules/home";
+
+export const metadata: Metadata = {
+  title: "React Kolkata Community | Meetups, Events & Learning",
+  description:
+    "Join React Kolkata, the hub for React developers in Kolkata. Participate in meetups, workshops, and connect with the community to build, learn, and grow.",
+  openGraph: {
+    title: "React Kolkata Community | Meetups, Events & Learning",
+    description: "Connect with React developers in Kolkata. Join events, learn, and grow together.",
+    url: "/",
+    images: [
+      {
+        url: "/react-kolkata-meetup.png",
+        width: 1200,
+        height: 630,
+        alt: "React Kolkata Community Meetup",
+      },
+    ],
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "React Kolkata Community | Meetups, Events & Learning",
+    description: "Connect with React developers in Kolkata. Join events, learn, and grow together.",
+    images: ["/react-kolkata-meetup.png"],
+  },
+};
 
 export default function HomePage() {
   return <LandingPage />;

--- a/src/modules/home/meta/site.ts
+++ b/src/modules/home/meta/site.ts
@@ -1,7 +1,11 @@
 import { Metadata } from "next";
 
 export const siteConfig: Metadata = {
-  title: "React Kolkata",
+  metadataBase: new URL("https://reactkolkata.com"),
+  title: {
+    default: "React Kolkata | Community, Events & Learning",
+    template: "%s | React Kolkata",
+  },
   description:
     "React Kolkata is a community of React enthusiasts in Kolkata. Join us for meetups, talks, workshops, and resources.",
   keywords: [
@@ -28,20 +32,26 @@ export const siteConfig: Metadata = {
     description:
       "Join React Kolkata for meetups, talks, workshops, and resources. A modern hub for React developers in Kolkata.",
     url: "https://reactkolkata.com",
+    siteName: "React Kolkata",
     images: [
       {
-        url: "react-kolkata-meetup.png",
+        url: "/react-kolkata-meetup.png",
         width: 1200,
         height: 630,
         alt: "React Kolkata Community",
       },
     ],
+    locale: "en_US",
+    type: "website",
   },
   twitter: {
     card: "summary_large_image",
     title: "React Kolkata — Community, Events, Resources",
     description:
       "Join React Kolkata for meetups, talks, workshops, and resources. A modern hub for React developers in Kolkata.",
+    images: ["/react-kolkata-meetup.png"],
+    // Optional: can add Twitter site handle
+    site: "@ReactKolkata",
   },
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "white" },
@@ -54,5 +64,4 @@ export const siteConfig: Metadata = {
   },
 };
 
-// storing constant to hit hashnode api call
 export const HASHNODE_API_URL = "https://gql.hashnode.com";


### PR DESCRIPTION
Resolves #38. Adds titles, descriptions, OpenGraph, and Twitter cards using Next.js Metadata API. Adds Organization JSON-LD to root layout.

## Summary

This PR implements crucial SEO enhancements as outlined in Issue #38. It utilizes the Next.js Metadata API to add unique titles, descriptions, OpenGraph tags, and Twitter Card tags to the main pages. It also adds site-wide `Organization` structured data using JSON-LD.

## Changes

* **`src/modules/home/meta/site.ts`**:
    * Added `metadataBase` for constructing absolute URLs (e.g., for images).
    * Added `title.template` for consistent page titles across the site.
    * Updated default `openGraph` and `twitter` tags (added `siteName`, relative image paths).
* **`src/app/[locale]/layout.tsx`**:
    * Added a `<Script>` tag to embed `Organization` JSON-LD structured data in the `<body>`.
* **`src/app/[locale]/page.tsx` (Homepage)**:
    * Exported a `metadata` object with a specific title, description, OpenGraph, and Twitter tags.
* **`src/app/[locale]/contributors/page.tsx`**:
    * Updated the existing `generateMetadata` function to include `openGraph` and `twitter` objects.
* **`src/app/[locale]/events/page.tsx`**:
    * Added a `generateMetadata` function to provide title, description, `openGraph`, and `twitter` tags using translations.
* **`src/app/[locale]/blog/page.tsx`**:
    * Added a `generateMetadata` function to provide title, description, `openGraph`, and `twitter` tags using translations.

## Testing

I tested these changes locally by:
1.  Running the project using `pnpm run dev`.
2.  Manually inspecting the `<head>` section using "View Page Source" for the following pages:
    * Homepage (`/`)
    * Contributors (`/contributors`)
    * Events (`/events`)
    * Blog (`/blog`)
3.  Verified that:
    * Each page has the correct `<title>` (using the template where applicable).
    * Each page has the correct `<meta name="description">`.
    * Each page has the appropriate `<meta property="og:...">` tags.
    * Each page has the appropriate `<meta name="twitter:...">` tags.
    * The `Organization` JSON-LD `<script>` tag is present on all pages (via the root layout).
4.  Confirmed that online validation tools (Schema Validator, Twitter Card Validator) fail on `localhost` URLs as expected, but the generated source code contains the correct tags.

## Related Issue

Resolves #38

## Notes

* This PR implements the requested SEO tags for all *existing* pages.
* JSON-LD for individual `BlogPosting` and `Event` schemas was **not** implemented because the corresponding dynamic pages (`blog/[slug]` and `events/[id]`) do not currently exist in the project structure. This can be added later when those pages are built.
* The console warnings regarding `themeColor` and image `sizes` props are unrelated to this PR and can be addressed separately.