### PR TITLE
feat(nav): add scroll link to Core Team section (Closes #107)

### DIFF
--- a/src/components/common/navbar/index.tsx
+++ b/src/components/common/navbar/index.tsx
@@ -2,13 +2,13 @@
 
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import NextLink from "next/link";
+import NextLink from "next/link"; // Use NextLink for external and hash links
 import { trackGAEvent } from "@/utils/analytics";
 import { Github, Linkedin, Menu, X, Youtube } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { SiDiscord } from "react-icons/si";
 
-import { Link, usePathname } from "@/config/i18n/navigation";
+import { Link, usePathname } from "@/config/i18n/navigation"; // Use Link for internal page routes
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { LanguageSwitcher } from "@/components/custom/language-switcher";
@@ -22,9 +22,10 @@ const Navbar = () => {
   const t = useTranslations("Navbar");
 
   const links = [
-    { href: "/", label: t("home"), external: false },
-    { href: "/contributors", label: t("contributors"), external: false },
-    { href: "/events", label: t("events"), external: false },
+    { href: "/", label: t("home"), external: false, isHashLink: false },
+    { href: "/#core-team", label: t("core_team"), external: false, isHashLink: true },
+    { href: "/contributors", label: t("contributors"), external: false, isHashLink: false },
+    { href: "/events", label: t("events"), external: false, isHashLink: false },
   ];
 
   const handleJoinClick = () => {
@@ -70,8 +71,12 @@ const Navbar = () => {
 
         <nav className="hidden items-center gap-1 md:flex" aria-label="Primary">
           {links.map((l) => {
-            const active = l.href === "/" ? pathname === l.href : pathname.startsWith(l.href);
-            const LinkComponent = l.external ? NextLink : Link;
+            const checkPath = l.isHashLink ? l.href.split("#")[0] : l.href;
+            const active =
+              checkPath === "/" ? pathname === checkPath : pathname.startsWith(checkPath);
+            // Use NextLink for external or hash links, use localized Link otherwise
+            const LinkComponent = l.external || l.isHashLink ? NextLink : Link;
+
             return (
               <LinkComponent
                 key={l.href}
@@ -80,7 +85,12 @@ const Navbar = () => {
                 rel={l.external ? "noopener noreferrer" : undefined}
                 className={cn(
                   "rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                  active ? "text-sky-300" : "text-slate-300 hover:text-white"
+                  // Style hash link normally, active style based on path match
+                  l.isHashLink
+                    ? "text-slate-300 hover:text-white"
+                    : active
+                      ? "text-sky-300"
+                      : "text-slate-300 hover:text-white"
                 )}
               >
                 {l.label}
@@ -154,9 +164,9 @@ const Navbar = () => {
               className="bg-gradient-to-r from-blue-600 to-sky-500 hover:from-blue-500 hover:to-sky-400"
               onClick={handleJoinClick}
             >
-              <Link href="https://chat.whatsapp.com/JmCp4Za9ap0DpER0Gd4hAs" target="_blank">
+              <NextLink href="https://chat.whatsapp.com/JmCp4Za9ap0DpER0Gd4hAs" target="_blank">
                 {t("join_community")}
-              </Link>
+              </NextLink>
             </Button>
           </div>
         </div>
@@ -175,8 +185,11 @@ const Navbar = () => {
         <div className="absolute right-0 w-1/2 border-t border-white/5 bg-[#0B1220] md:hidden">
           <nav className="mx-auto grid max-w-7xl gap-1 px-4 py-3 sm:px-6" aria-label="Mobile">
             {links.map((l) => {
-              const active = l.href === "/" ? pathname === l.href : pathname.startsWith(l.href);
-              const LinkComponent = l.external ? NextLink : Link;
+              const checkPath = l.isHashLink ? l.href.split("#")[0] : l.href;
+              const active =
+                checkPath === "/" ? pathname === checkPath : pathname.startsWith(checkPath);
+              const LinkComponent = l.external || l.isHashLink ? NextLink : Link;
+
               return (
                 <LinkComponent
                   key={l.href}
@@ -185,9 +198,11 @@ const Navbar = () => {
                   rel={l.external ? "noopener noreferrer" : undefined}
                   className={cn(
                     "rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                    active
-                      ? "bg-white/5 text-sky-300"
-                      : "text-slate-300 hover:bg-white/5 hover:text-white"
+                    l.isHashLink
+                      ? "text-slate-300 hover:bg-white/5 hover:text-white"
+                      : active
+                        ? "bg-white/5 text-sky-300"
+                        : "text-slate-300 hover:bg-white/5 hover:text-white"
                   )}
                 >
                   {l.label}

--- a/src/config/i18n/content/bn.json
+++ b/src/config/i18n/content/bn.json
@@ -110,6 +110,7 @@
   },
   "Navbar": {
     "home": "হোম",
+    "core_team": "মূল দল",
     "contributors": "অবদানকারী",
     "events": "ইভেন্ট",
     "join_community": "কমিউনিটিতে যোগ দিন",

--- a/src/config/i18n/content/en.json
+++ b/src/config/i18n/content/en.json
@@ -110,6 +110,7 @@
   },
   "Navbar": {
     "home": "Home",
+    "core_team": "Core Team",
     "contributors": "Contributors",
     "events": "Events",
     "join_community": "Join the Community",

--- a/src/config/i18n/content/hi.json
+++ b/src/config/i18n/content/hi.json
@@ -110,6 +110,7 @@
   },
   "Navbar": {
     "home": "होम",
+    "core_team": "मूल समूह",
     "contributors": "योगदानकर्ता",
     "events": "इवेंट्स",
     "join_community": "कम्युनिटी में शामिल हों",

--- a/src/modules/home/(sections)/about/core-team/index.tsx
+++ b/src/modules/home/(sections)/about/core-team/index.tsx
@@ -36,7 +36,7 @@ const members = [
 ];
 
 const CoreTeam = () => (
-  <section className="py-10 text-center">
+  <section id="core-team" className="py-10 text-center">
     <h2
       className="mb-8 text-3xl font-bold text-slate-100"
       style={{ fontFamily: "var(--font-poppins)" }}


### PR DESCRIPTION
Resolves #107. Adds 'Core Team' link to navbar that scrolls to the existing section on the homepage.

## Summary

This PR implements the first part of the suggestion in Issue #107, as clarified by @priyankarpal. It adds a "Core Team" link to the main navigation that, when clicked, smoothly scrolls the user to the existing "Core Team" section on the homepage.

## Changes

* **`src/modules/home/(sections)/core-team/index.tsx`**: Added `id="core-team"` to the main `<section>` element.
* **`src/components/common/navbar/index.tsx`**:
    * Added a new entry `{ href: "/#core-team", label: t("core_team"), isHashLink: true }` to the `links` array.
    * Updated link rendering logic to use `NextLink` for hash links to ensure proper scrolling behavior.
* **i18n JSON files (`en.json`, `bn.json`, `hi.json`)**: Added the `core_team` translation key under the `Navbar` object.

## Testing

I tested these changes locally by:
1.  Running the project using `pnpm run dev`.
2.  Navigating to the homepage (`/`).
3.  Clicking the new "Core Team" link in the navbar and verifying it smoothly scrolled to the correct section.
4.  Navigating to another page (e.g., `/contributors`).
5.  Clicking the "Core Team" link again and verifying it navigated back to the homepage and scrolled down to the section.

![Screenshot 2025-10-28 at 12 45 32 AM](https://github.com/user-attachments/assets/cabcf0bf-72ea-4f6c-b5f8-8febe3fd6089)

## Related Issue

Resolves #107 (implements the scroll link part)

## Notes

This PR only adds the scroll link. Creating a separate page for the Core Team section can be done later as suggested in the original issue discussion.