### PR TITLE
fix(i18n): resolve Hindi locale delay by correcting routing and middl…

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import createMiddleware from "next-intl/middleware";
 
 import { routing } from "@/config/i18n/navigation";
 
-export const middleware = createMiddleware(routing);
+export default createMiddleware(routing);
 
 export const config = {
   matcher: ["/((?!api|_next|.*\\..*).*)"],


### PR DESCRIPTION
Fixed Hindi ↔ English locale switching delay by correcting middleware export and ensuring proper locale configuration in navigation.ts.

Tested locally — language switching now works instantly without redirect loops.