### PR TITLE
fix: footer note at contributors page was glitching on fast scroll up

### DIFF
--- a/src/components/custom/animated-section/index.tsx
+++ b/src/components/custom/animated-section/index.tsx
@@ -33,6 +33,7 @@ export default function AnimatedSection({
       initial="hidden"
       whileInView="show"
       viewport={{ once: true, amount: 0.1, margin: "0px 0px -100px 0px" }}
+      style={{ willChange: "transform, opacity" }}
     >
       {children}
     </motion.section>


### PR DESCRIPTION
## Summary
Footer note animation was overlapping with the fast scrolling and was creating a glitch effect which is fixed here.

## Changes
Added: `style={{ willChange: "transform, opacity" }}` at motion.selection

